### PR TITLE
Fix issues with non-Safari browsers

### DIFF
--- a/examples/Basic/data/script.js
+++ b/examples/Basic/data/script.js
@@ -92,12 +92,11 @@ function onSaveButtonClicked(event) {
         password: $('#password').val()
     };
 
-    //NB dataType is 'text' otherwise json validation fails on Safari
-    $.ajax({
+    var request = {
         type: "POST",
         url: "/yoyo/credentials",
         data: JSON.stringify(data),
-        dataType: 'text',
+        dataType: 'json',
         contentType: 'application/json; charset=utf-8',
         cache: false,
         timeout: 15000,
@@ -119,5 +118,13 @@ function onSaveButtonClicked(event) {
             $('#alert-text').addClass('alert-danger');
             $('#alert-text').text('Couldn\'t Save');
         }
-    });
+    }
+
+    //json validation fails on Safari - but if defaults to text then fails on Windows/Android
+    if (navigator.userAgent.indexOf('Safari') != -1 && navigator.userAgent.indexOf('Chrome') == -1 && navigator.userAgent.indexOf('Chromium') == -1) {
+        request.dataType = 'text';
+    }
+
+    $.ajax(request);
 }
+

--- a/examples/BasicWithEndpoints/data/script.js
+++ b/examples/BasicWithEndpoints/data/script.js
@@ -92,12 +92,11 @@ function onSaveButtonClicked(event) {
         password: $('#password').val()
     };
 
-    //NB dataType is 'text' otherwise json validation fails on Safari
-    $.ajax({
+    var request = {
         type: "POST",
-        url: "/yoyo/settings",
+        url: "/yoyo/credentials",
         data: JSON.stringify(data),
-        dataType: 'text',
+        dataType: 'json',
         contentType: 'application/json; charset=utf-8',
         cache: false,
         timeout: 15000,
@@ -119,5 +118,12 @@ function onSaveButtonClicked(event) {
             $('#alert-text').addClass('alert-danger');
             $('#alert-text').text('Couldn\'t Save');
         }
-    });
+    }
+
+    //json validation fails on Safari - but if defaults to text then fails on Windows/Android
+    if (navigator.userAgent.indexOf('Safari') != -1 && navigator.userAgent.indexOf('Chrome') == -1 && navigator.userAgent.indexOf('Chromium') == -1) {
+        request.dataType = 'text';
+    }
+
+    $.ajax(request);
 }

--- a/src/YoYoWiFiManager.h
+++ b/src/YoYoWiFiManager.h
@@ -237,8 +237,6 @@ class YoYoWiFiManager : public AsyncWebHandler {
     void getClients(AsyncWebServerRequest *request);
     void getPeers(AsyncWebServerRequest *request);
     void getCredentials(AsyncWebServerRequest *request);
-    
-    bool setCredentials(JsonVariant message, AsyncWebServerRequest *request);
 };
 
 #endif


### PR DESCRIPTION
Would often fail to save credentials when using the captive portal with non-Safari browsers on windows/android devices